### PR TITLE
feat: add function ordering rule for top-level functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
     - [Check exported methods are placed before unexported methods](#check-exported-methods-are-placed-before-unexported-methods)
     - [Check `Constructors` functions are placed after struct declaration](#check-constructors-functions-are-placed-after-struct-declaration)
     - [Check Constructors/Methods are sorted alphabetically](#check-constructorsmethods-are-sorted-alphabetically)
+    - [Check exported functions are placed before unexported functions](#check-exported-functions-are-placed-before-unexported-functions)
   - [Resources](#resources)
 
 Go Linter to check Functions/Methods Order.
@@ -38,6 +39,9 @@ linters:
       # Checks if the constructors and/or structure methods are sorted alphabetically.
       # Default: false
       alphabetical: true
+      # Checks that exported functions are placed before unexported functions.
+      # Default: false
+      function: true
 ```
 
 ### Standalone application
@@ -51,7 +55,7 @@ go install github.com/manuelarte/funcorder@latest
 And then use it with
 
 ```
-funcorder [-constructor=true|false] [-struct-method=true|false] [-alphabetical=true|false] ./...
+funcorder [-constructor=true|false] [-struct-method=true|false] [-alphabetical=true|false] [-function=true|false] ./...
 ```
 
 Parameters:
@@ -59,6 +63,7 @@ Parameters:
 - `constructor`: `true|false` (default `true`) Checks that constructors are placed after the structure declaration.
 - `struct-method`: `true|false` (default `true`) Checks if the exported methods of a structure are placed before the unexported ones.
 - `alphabetical`: `true|false` (default `false`) Checks if the constructors and/or structure methods are sorted alphabetically.
+- `function`: `true|false` (default `false`) Checks that exported functions are placed before unexported functions.
 
 ## 🚀 Features
 
@@ -257,6 +262,48 @@ func (m MyStruct) hello() string {
 
 </tbody>
 </table>
+
+### Check exported functions are placed before unexported functions
+
+This rule checks that exported functions (those with no receiver) are placed before unexported ones within each file. The `init` function is excluded from this rule.
+
+<table>
+<thead><tr><th>❌ Bad</th><th>✅ Good</th></tr></thead>
+<tbody>
+<tr><td>
+
+```go
+// ❌ unexported function placed
+// before exported function
+func helper() string {
+    return "helper"
+}
+
+func PublicFunc() string {
+    return "public"
+}
+```
+
+</td><td>
+
+```go
+// ✅ exported function placed
+// before unexported function
+func PublicFunc() string {
+    return "public"
+}
+
+func helper() string {
+    return "helper"
+}
+```
+
+</td></tr>
+
+</tbody>
+</table>
+
+> **Note:** When this change is merged upstream and consumed by golangci-lint, enable this rule by adding `function: true` under `linters.settings.funcorder` in your golangci-lint configuration.
 
 ## Resources
 

--- a/README.md
+++ b/README.md
@@ -265,7 +265,8 @@ func (m MyStruct) hello() string {
 
 ### Check exported functions are placed before unexported functions
 
-This rule checks that exported functions (those with no receiver) are placed before unexported ones within each file. The `init` function is excluded from this rule.
+This rule checks that exported functions (those with no receiver) are placed before unexported ones within each file.
+The `init` function is excluded from this rule.
 
 <table>
 <thead><tr><th>❌ Bad</th><th>✅ Good</th></tr></thead>
@@ -302,8 +303,6 @@ func helper() string {
 
 </tbody>
 </table>
-
-> **Note:** When this change is merged upstream and consumed by golangci-lint, enable this rule by adding `function: true` under `linters.settings.funcorder` in your golangci-lint configuration.
 
 ## Resources
 

--- a/analyzer/analyzer.go
+++ b/analyzer/analyzer.go
@@ -11,9 +11,10 @@ import (
 )
 
 const (
-	ConstructorCheckName  = "constructor"
-	StructMethodCheckName = "struct-method"
-	AlphabeticalCheckName = "alphabetical"
+	ConstructorCheckName       = "constructor"
+	StructMethodCheckName      = "struct-method"
+	AlphabeticalCheckName      = "alphabetical"
+	PackageLevelOrderCheckName = "function"
 )
 
 func NewAnalyzer() *analysis.Analyzer {
@@ -33,14 +34,17 @@ func NewAnalyzer() *analysis.Analyzer {
 		"Checks if the exported methods of a structure are placed before the unexported ones.")
 	a.Flags.BoolVar(&f.alphabeticalCheck, AlphabeticalCheckName, false,
 		"Checks if the constructors and/or structure methods are sorted alphabetically.")
+	a.Flags.BoolVar(&f.packageLevelOrderCheck, PackageLevelOrderCheckName, false,
+		"Checks that exported functions are placed before unexported functions.")
 
 	return a
 }
 
 type funcorder struct {
-	constructorCheck  bool
-	structMethodCheck bool
-	alphabeticalCheck bool
+	constructorCheck       bool
+	structMethodCheck      bool
+	alphabeticalCheck      bool
+	packageLevelOrderCheck bool
 }
 
 func (f *funcorder) run(pass *analysis.Pass) (any, error) {
@@ -61,6 +65,10 @@ func (f *funcorder) run(pass *analysis.Pass) (any, error) {
 
 	if f.alphabeticalCheck {
 		enabledCheckers.Enable(internal.AlphabeticalCheck)
+	}
+
+	if f.packageLevelOrderCheck {
+		enabledCheckers.Enable(internal.FunctionCheck)
 	}
 
 	fp := internal.NewFileProcessor(enabledCheckers)

--- a/analyzer/analyzer.go
+++ b/analyzer/analyzer.go
@@ -11,10 +11,10 @@ import (
 )
 
 const (
-	ConstructorCheckName       = "constructor"
-	StructMethodCheckName      = "struct-method"
-	AlphabeticalCheckName      = "alphabetical"
-	PackageLevelOrderCheckName = "function"
+	ConstructorCheckName  = "constructor"
+	StructMethodCheckName = "struct-method"
+	AlphabeticalCheckName = "alphabetical"
+	FunctionCheckName     = "function"
 )
 
 func NewAnalyzer() *analysis.Analyzer {
@@ -34,17 +34,17 @@ func NewAnalyzer() *analysis.Analyzer {
 		"Checks if the exported methods of a structure are placed before the unexported ones.")
 	a.Flags.BoolVar(&f.alphabeticalCheck, AlphabeticalCheckName, false,
 		"Checks if the constructors and/or structure methods are sorted alphabetically.")
-	a.Flags.BoolVar(&f.packageLevelOrderCheck, PackageLevelOrderCheckName, false,
+	a.Flags.BoolVar(&f.functionCheck, FunctionCheckName, false,
 		"Checks that exported functions are placed before unexported functions.")
 
 	return a
 }
 
 type funcorder struct {
-	constructorCheck       bool
-	structMethodCheck      bool
-	alphabeticalCheck      bool
-	packageLevelOrderCheck bool
+	constructorCheck  bool
+	structMethodCheck bool
+	alphabeticalCheck bool
+	functionCheck     bool
 }
 
 func (f *funcorder) run(pass *analysis.Pass) (any, error) {
@@ -67,7 +67,7 @@ func (f *funcorder) run(pass *analysis.Pass) (any, error) {
 		enabledCheckers.Enable(internal.AlphabeticalCheck)
 	}
 
-	if f.packageLevelOrderCheck {
+	if f.functionCheck {
 		enabledCheckers.Enable(internal.FunctionCheck)
 	}
 

--- a/analyzer/analyzer_test.go
+++ b/analyzer/analyzer_test.go
@@ -66,6 +66,15 @@ func TestAnalyzer(t *testing.T) {
 				AlphabeticalCheckName: "false",
 			},
 		},
+		{
+			desc:     "function order check",
+			patterns: "function-order",
+			options: map[string]string{
+				ConstructorCheckName:       "false",
+				StructMethodCheckName:      "false",
+				PackageLevelOrderCheckName: "true",
+			},
+		},
 	}
 
 	for _, test := range testCases {

--- a/analyzer/analyzer_test.go
+++ b/analyzer/analyzer_test.go
@@ -70,9 +70,9 @@ func TestAnalyzer(t *testing.T) {
 			desc:     "function order check",
 			patterns: "function-order",
 			options: map[string]string{
-				ConstructorCheckName:       "false",
-				StructMethodCheckName:      "false",
-				PackageLevelOrderCheckName: "true",
+				ConstructorCheckName:  "false",
+				StructMethodCheckName: "false",
+				FunctionCheckName:     "true",
 			},
 		},
 	}

--- a/analyzer/testdata/src/function-order/correct_order.go
+++ b/analyzer/testdata/src/function-order/correct_order.go
@@ -1,4 +1,4 @@
-package packagelevelorder
+package functionorder
 
 // exported functions appear before unexported — no violation.
 

--- a/analyzer/testdata/src/function-order/correct_order.go
+++ b/analyzer/testdata/src/function-order/correct_order.go
@@ -1,0 +1,11 @@
+package packagelevelorder
+
+// exported functions appear before unexported — no violation.
+
+func AnotherPublicFunc() string {
+	return "another public"
+}
+
+func anotherHelper() string {
+	return "another helper"
+}

--- a/analyzer/testdata/src/function-order/exported_after_unexported.go
+++ b/analyzer/testdata/src/function-order/exported_after_unexported.go
@@ -1,0 +1,11 @@
+package packagelevelorder
+
+// unexported function appears before exported — violation expected.
+
+func helper() string { // want `unexported function "helper" should be placed after the exported function "PublicFunc"`
+	return "helper"
+}
+
+func PublicFunc() string {
+	return "public"
+}

--- a/analyzer/testdata/src/function-order/exported_after_unexported.go
+++ b/analyzer/testdata/src/function-order/exported_after_unexported.go
@@ -1,4 +1,4 @@
-package packagelevelorder
+package functionorder
 
 // unexported function appears before exported — violation expected.
 

--- a/analyzer/testdata/src/function-order/init_excluded.go
+++ b/analyzer/testdata/src/function-order/init_excluded.go
@@ -1,4 +1,4 @@
-package packagelevelorder
+package functionorder
 
 // init is excluded from the rule; exported function after init must not be reported.
 

--- a/analyzer/testdata/src/function-order/init_excluded.go
+++ b/analyzer/testdata/src/function-order/init_excluded.go
@@ -1,0 +1,11 @@
+package packagelevelorder
+
+// init is excluded from the rule; exported function after init must not be reported.
+
+func init() {
+	// setup
+}
+
+func ExportedAfterInit() string {
+	return "ok"
+}

--- a/internal/features.go
+++ b/internal/features.go
@@ -4,6 +4,7 @@ const (
 	ConstructorCheck Feature = 1 << iota
 	StructMethodCheck
 	AlphabeticalCheck
+	FunctionCheck
 )
 
 type Feature uint8

--- a/internal/file_processor.go
+++ b/internal/file_processor.go
@@ -31,52 +31,13 @@ func (fp *FileProcessor) Analyze(pass *analysis.Pass) {
 	}
 
 	if fp.features.IsEnabled(FunctionCheck) {
-		fp.analyzeFunctionOrder(pass)
+		fp.analyzeFunctions(pass)
 	}
 }
 
 func (fp *FileProcessor) ResetStructs() {
 	fp.structs = make(map[string]*StructHolder)
 	fp.topLevelFuncs = nil
-}
-
-// analyzeFunctionOrder reports every unexported top-level function that appears
-// before the last exported top-level function in source order.
-// The init function is excluded from this check.
-func (fp *FileProcessor) analyzeFunctionOrder(pass *analysis.Pass) {
-	// Find the last exported function (highest position).
-	var lastExported *ast.FuncDecl
-
-	for _, fn := range fp.topLevelFuncs {
-		if fn.Name.Name == "init" {
-			continue
-		}
-
-		if !fn.Name.IsExported() {
-			continue
-		}
-
-		if lastExported == nil || fn.Pos() > lastExported.Pos() {
-			lastExported = fn
-		}
-	}
-
-	if lastExported == nil {
-		return
-	}
-
-	// Report every unexported function that appears before the last exported one.
-	for _, fn := range fp.topLevelFuncs {
-		if fn.Name.Name == "init" {
-			continue
-		}
-
-		if fn.Name.IsExported() || fn.Pos() >= lastExported.Pos() {
-			continue
-		}
-
-		reportUnexportedFuncBeforeExportedFunc(pass, fn, lastExported)
-	}
 }
 
 func (fp *FileProcessor) AddFuncDecl(n *ast.FuncDecl) {
@@ -101,6 +62,43 @@ func (fp *FileProcessor) AddFuncDecl(n *ast.FuncDecl) {
 func (fp *FileProcessor) AddTypeSpec(n *ast.TypeSpec) {
 	sh := fp.getOrCreate(n.Name.Name)
 	sh.Struct = n
+}
+
+// analyzeFunctions reports every unexported top-level function that appears
+// before the last exported top-level function in source order.
+// The `init` function is excluded from this check.
+func (fp *FileProcessor) analyzeFunctions(pass *analysis.Pass) {
+	var lastExported *ast.FuncDecl
+
+	for _, fn := range fp.topLevelFuncs {
+		if fn.Name.Name == "init" {
+			continue
+		}
+
+		if !fn.Name.IsExported() {
+			continue
+		}
+
+		if lastExported == nil || fn.Pos() > lastExported.Pos() {
+			lastExported = fn
+		}
+	}
+
+	if lastExported == nil {
+		return
+	}
+
+	for _, fn := range fp.topLevelFuncs {
+		if fn.Name.Name == "init" {
+			continue
+		}
+
+		if fn.Name.IsExported() || fn.Pos() >= lastExported.Pos() {
+			continue
+		}
+
+		reportUnexportedFuncBeforeExportedFunc(pass, fn, lastExported)
+	}
 }
 
 func (fp *FileProcessor) getOrCreate(structName string) *StructHolder {

--- a/internal/file_processor.go
+++ b/internal/file_processor.go
@@ -8,8 +8,9 @@ import (
 
 // FileProcessor Holder to store all the functions that are potential to be constructors and all the structs.
 type FileProcessor struct {
-	structs  map[string]*StructHolder
-	features Feature
+	structs       map[string]*StructHolder
+	features      Feature
+	topLevelFuncs []*ast.FuncDecl
 }
 
 // NewFileProcessor creates a new file processor.
@@ -28,13 +29,62 @@ func (fp *FileProcessor) Analyze(pass *analysis.Pass) {
 			sh.Analyze(pass)
 		}
 	}
+
+	if fp.features.IsEnabled(FunctionCheck) {
+		fp.analyzeFunctionOrder(pass)
+	}
 }
 
 func (fp *FileProcessor) ResetStructs() {
 	fp.structs = make(map[string]*StructHolder)
+	fp.topLevelFuncs = nil
+}
+
+// analyzeFunctionOrder reports every unexported top-level function that appears
+// before the last exported top-level function in source order.
+// The init function is excluded from this check.
+func (fp *FileProcessor) analyzeFunctionOrder(pass *analysis.Pass) {
+	// Find the last exported function (highest position).
+	var lastExported *ast.FuncDecl
+
+	for _, fn := range fp.topLevelFuncs {
+		if fn.Name.Name == "init" {
+			continue
+		}
+
+		if !fn.Name.IsExported() {
+			continue
+		}
+
+		if lastExported == nil || fn.Pos() > lastExported.Pos() {
+			lastExported = fn
+		}
+	}
+
+	if lastExported == nil {
+		return
+	}
+
+	// Report every unexported function that appears before the last exported one.
+	for _, fn := range fp.topLevelFuncs {
+		if fn.Name.Name == "init" {
+			continue
+		}
+
+		if fn.Name.IsExported() || fn.Pos() >= lastExported.Pos() {
+			continue
+		}
+
+		reportUnexportedFuncBeforeExportedFunc(pass, fn, lastExported)
+	}
 }
 
 func (fp *FileProcessor) AddFuncDecl(n *ast.FuncDecl) {
+	// Accumulate all top-level functions (no receiver) for the package-level order check.
+	if fp.features.IsEnabled(FunctionCheck) && n.Recv == nil {
+		fp.topLevelFuncs = append(fp.topLevelFuncs, n)
+	}
+
 	if sc := NewStructConstructor(n); sc != nil {
 		sh := fp.getOrCreate(sc.StructReturn.Name)
 		sh.Constructors = append(sh.Constructors, sc.Constructor)

--- a/internal/file_processor.go
+++ b/internal/file_processor.go
@@ -41,7 +41,6 @@ func (fp *FileProcessor) ResetStructs() {
 }
 
 func (fp *FileProcessor) AddFuncDecl(n *ast.FuncDecl) {
-	// Accumulate all top-level functions (no receiver) for the package-level order check.
 	if fp.features.IsEnabled(FunctionCheck) && n.Recv == nil {
 		fp.topLevelFuncs = append(fp.topLevelFuncs, n)
 	}

--- a/internal/reports.go
+++ b/internal/reports.go
@@ -67,3 +67,12 @@ func reportAdjacentStructMethodsNotSortedAlphabetically(
 			otherMethod.Name, structSpec.Name, method.Name),
 	})
 }
+
+func reportUnexportedFuncBeforeExportedFunc(pass *analysis.Pass, unexportedFunc, exportedFunc *ast.FuncDecl) {
+	pass.Report(analysis.Diagnostic{
+		Pos: unexportedFunc.Pos(),
+		URL: "https://github.com/manuelarte/funcorder?tab=readme-ov-file#check-exported-functions-are-placed-before-unexported-functions", //nolint:lll // url
+		Message: fmt.Sprintf("unexported function %q should be placed after the exported function %q",
+			unexportedFunc.Name, exportedFunc.Name),
+	})
+}


### PR DESCRIPTION
Adds a new optional `function` rule (default: off) that enforces exported
top-level functions appear before unexported top-level functions within each
file.

The existing `struct-method` rule enforces export ordering for struct methods
but there was no equivalent for plain top-level functions.

`init` is excluded from the rule
